### PR TITLE
Fix removing files when using --inplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # backstopjs-failsonly
 Script to reduce download size for backstopjs screenshots if you happy with a failure only report
 
-This script asumes that it is located in `backstop_data/pipelines/error-report-only.sh` within your backstop test result. 
+This script asumes that it is located in `backstop_data/pipeline_scripts/error-report-only.sh` within your backstop test result.
 
-By default stis script creates a copy of `backstop_data` names `backstop_data_failonly`, which contains only the faild end test, reference and diff pngs and an updated html_report with only failed tests. 
+By default this script creates a copy of `backstop_data` names `backstop_data_failonly`, which contains only the failed test, reference and diff pngs and an updated html_report with only failed tests.
 
 ```
 error-report-only.sh
 ```
 
-If directory `backtop_data/../backstop_data_failonly/` exists you can delete and create a new copy with
+If the directory `backtop_data/../backstop_data_failonly/` exists you can delete and create a new copy with
 
 ```
 error-report-only.sh --replace-existing
@@ -26,7 +26,7 @@ To keep things tiny the **copy** option uses a whitelist.
  ...
 ```
 
-The **inplace** option it might be faster. 
+The **inplace** option might be faster.
 
 It *deletes the successful* test and reference images and also updates html_report with only failed tests.
 
@@ -39,9 +39,9 @@ error-report-only.sh --inplace
 Intended use is to create two download assets `backstop_data` and `backstop_data_failonly` so you can download less if you want references for a few failed tests. 
 
 ```
-mkdir -p backstopjs/backstop_data/pipeline_sctipts/ \
-&& wget https://raw.githubusercontent.com/digitaldonkey/backstopjs-failsonly/0.0.1-alpha/dist/error-report-only.sh?token=XXXXXXXXXXXXXXXXXXXXXXXXXXX -O backstopjs/backstop_data/pipeline_sctipts/error-report-only.sh \
-&& chmod a+x backstopjs/backstop_data/pipeline_sctipts/error-report-only.sh \
-&& backstopjs/backstop_data/pipeline_sctipts/error-report-only.sh \
+mkdir -p backstopjs/backstop_data/pipeline_scripts/ \
+&& wget https://raw.githubusercontent.com/digitaldonkey/backstopjs-failsonly/0.0.1-alpha/dist/error-report-only.sh?token=XXXXXXXXXXXXXXXXXXXXXXXXXXX -O backstopjs/backstop_data/pipeline_scripts/error-report-only.sh \
+&& chmod a+x backstopjs/backstop_data/pipeline_scripts/error-report-only.sh \
+&& backstopjs/backstop_data/pipeline_scripts/error-report-only.sh \
 && open backstopjs/backstop_data_failonly/html_report/index.html
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ if (argv.inplace) {
 
   report.files.forEach((p) => {  	
   	if (p.substring(0,1) === '!') {
-  	  const fileName = p.substring(1)
+	  const fileName = `${report.dest}/${p.substring(1)}`
   	  if (fs.existsSync(fileName)) {
   	    fs.unlink(fileName, (err) => {
           if (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ const argv = yargs(hideBin(process.argv)).argv
 const chalk = require('chalk');
 const fs = require('fs')
 const path = require('path');
-const JSONP = require('node-jsonp');
 
 const copy = require('recursive-copy');
 


### PR DESCRIPTION
Hey, thanks for the handy tool!

This fixes an issue where deleting the successful files won't work. Trying to do an `--inplace` won't work due to:

```
Could not delete file:
  bitmaps_test/20210406-182537/img.png
```

The script doesn't know in which subdir the files are located.

Apart from that, the .lock file is quite outdated and still references `webpack-test` with version `1.0.0`. Didn't want to blow up this PR but I can push the changes if you'd like, just let me know (same for the dist build and version in the `package.json`.